### PR TITLE
Added extra tables EcomCurrencies, EcomCountries and EcomStockLocatio…

### DIFF
--- a/src/Dynamicweb.DataIntegration.Providers.EcomProvider.csproj
+++ b/src/Dynamicweb.DataIntegration.Providers.EcomProvider.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<Version>10.0.14</Version>
+		<Version>10.0.15</Version>
 		<AssemblyVersion>1.0.0.0</AssemblyVersion>
 		<Title>Ecom Provider</Title>
 		<Description>Ecom Provider</Description>

--- a/src/EcomDestinationWriter.cs
+++ b/src/EcomDestinationWriter.cs
@@ -3,6 +3,7 @@ using Dynamicweb.Core;
 using Dynamicweb.Data;
 using Dynamicweb.DataIntegration.Integration;
 using Dynamicweb.DataIntegration.ProviderHelpers;
+using Dynamicweb.Ecommerce.International;
 using Dynamicweb.Ecommerce.Stocks;
 using Dynamicweb.Logging;
 using System;
@@ -278,30 +279,32 @@ internal class EcomDestinationWriter : BaseSqlWriter
                 switch (table.Name)
                 {
                     case "EcomVariantGroups":
-                        EnsureDestinationColumn(columnMappingDictionary, destColumns, destinationTableColumns, "VariantGroupID");
-                        EnsureDestinationColumn(columnMappingDictionary, destColumns, destinationTableColumns, "VariantGroupLanguageID");
+                        EnsureDestinationColumn(columnMappingDictionary, destColumns, "VariantGroupID", typeof(string), SqlDbType.NVarChar, null, 255, false, true, false);
+                        EnsureDestinationColumn(columnMappingDictionary, destColumns, "VariantGroupLanguageID", typeof(string), SqlDbType.NVarChar, null, 50, false, true, false);
                         break;
                     case "EcomVariantsOptions":
-                        EnsureDestinationColumn(columnMappingDictionary, destColumns, destinationTableColumns, "VariantOptionID");
-                        EnsureDestinationColumn(columnMappingDictionary, destColumns, destinationTableColumns, "VariantOptionLanguageID");
+                        EnsureDestinationColumn(columnMappingDictionary, destColumns, "VariantOptionID", typeof(string), SqlDbType.NVarChar, null, 255, false, true, false);
+                        EnsureDestinationColumn(columnMappingDictionary, destColumns, "VariantOptionLanguageID", typeof(string), SqlDbType.NVarChar, null, 50, false, true, false);
                         break;
                     case "EcomProducts":
-                        EnsureDestinationColumn(columnMappingDictionary, destColumns, destinationTableColumns, "ProductVariantID");
-                        EnsureDestinationColumn(columnMappingDictionary, destColumns, destinationTableColumns, "ProductID");
-                        EnsureDestinationColumn(columnMappingDictionary, destColumns, destinationTableColumns, "ProductLanguageID");
+                        EnsureDestinationColumn(columnMappingDictionary, destColumns, "ProductVariantID", typeof(string), SqlDbType.NVarChar, null, 255, false, true, false);
+                        EnsureDestinationColumn(columnMappingDictionary, destColumns, "ProductID", typeof(string), SqlDbType.NVarChar, null, 30, false, true, false);
+                        EnsureDestinationColumn(columnMappingDictionary, destColumns, "ProductLanguageID", typeof(string), SqlDbType.NVarChar, null, 50, false, true, false);
+                        EnsureDestinationColumn(columnMappingDictionary, destColumns, "ProductDefaultShopId", typeof(string), SqlDbType.NVarChar, null, 255, false, false, false);
                         EnsureDestinationColumn(columnMappingDictionary, destColumns, destinationTableColumns, "ProductVariantProdCounter");
                         EnsureDestinationColumn(columnMappingDictionary, destColumns, destinationTableColumns, "ProductVariantGroupCounter");
                         EnsureDestinationColumn(columnMappingDictionary, destColumns, destinationTableColumns, "ProductVariantCounter");
                         break;
                     case "EcomProductCategoryFieldValue":
-                        EnsureDestinationColumn(columnMappingDictionary, destColumns, destinationTableColumns, "FieldValueProductId");
-                        EnsureDestinationColumn(columnMappingDictionary, destColumns, destinationTableColumns, "FieldValueProductVariantId");
-                        EnsureDestinationColumn(columnMappingDictionary, destColumns, destinationTableColumns, "FieldValueProductLanguageId");
-                        EnsureDestinationColumn(columnMappingDictionary, destColumns, destinationTableColumns, "FieldValueFieldCategoryId");
+                        EnsureDestinationColumn(columnMappingDictionary, destColumns, "FieldValueFieldCategoryId", typeof(string), SqlDbType.NVarChar, null, 50, false, true, false);
+                        EnsureDestinationColumn(columnMappingDictionary, destColumns, "FieldValueProductId", typeof(string), SqlDbType.NVarChar, null, 30, false, true, false);
+                        EnsureDestinationColumn(columnMappingDictionary, destColumns, "FieldValueProductVariantId", typeof(string), SqlDbType.NVarChar, null, 255, false, true, false);
+                        EnsureDestinationColumn(columnMappingDictionary, destColumns, "FieldValueProductLanguageId", typeof(string), SqlDbType.NVarChar, null, 50, false, true, false);
                         break;
                     case "EcomPrices":
                         EnsureDestinationColumn(columnMappingDictionary, destColumns, destinationTableColumns, "PriceID");
-                        EnsureDestinationColumn(columnMappingDictionary, destColumns, destinationTableColumns, "PriceCurrency");
+                        EnsureDestinationColumn(columnMappingDictionary, destColumns, "PriceCurrency", typeof(string), SqlDbType.NVarChar, null, 3, false, true, false);
+                        EnsureDestinationColumn(columnMappingDictionary, destColumns, "PriceShopId", typeof(string), SqlDbType.NVarChar, null, 255, false, false, false);
                         break;
                     case "EcomGroups":
                         EnsureDestinationColumn(columnMappingDictionary, destColumns, "GroupLanguageID", typeof(string), SqlDbType.NVarChar, null, 50, false, true, false);
@@ -324,6 +327,7 @@ internal class EcomDestinationWriter : BaseSqlWriter
                         break;
                     case "EcomDetails":
                         EnsureDestinationColumn(columnMappingDictionary, destColumns, "DetailID", typeof(string), SqlDbType.NVarChar, null, 255, false, true, false);
+                        EnsureDestinationColumn(columnMappingDictionary, destColumns, "DetailLanguageId", typeof(string), SqlDbType.NVarChar, null, 50, false, false, false);
                         break;
                     case "EcomAssortmentPermissions":
                         EnsureDestinationColumn(columnMappingDictionary, destColumns, "AssortmentPermissionAccessUserID", typeof(string), SqlDbType.Int, null, -1, false, true, false);
@@ -331,6 +335,27 @@ internal class EcomDestinationWriter : BaseSqlWriter
                     case "EcomVariantOptionsProductRelation":
                         EnsureDestinationColumn(columnMappingDictionary, destColumns, "VariantOptionsProductRelationProductID", typeof(string), SqlDbType.NVarChar, null, 255, false, true, false);
                         EnsureDestinationColumn(columnMappingDictionary, destColumns, "VariantOptionsProductRelationVariantID", typeof(string), SqlDbType.NVarChar, null, 255, false, true, false);
+                        break;
+                    case "EcomAssortments":
+                        EnsureDestinationColumn(columnMappingDictionary, destColumns, "AssortmentLanguageID", typeof(string), SqlDbType.NVarChar, null, 50, false, true, false);
+                        break;
+                    case "EcomAssortmentShopRelations":
+                        EnsureDestinationColumn(columnMappingDictionary, destColumns, "AssortmentShopRelationShopID", typeof(string), SqlDbType.NVarChar, null, 255, false, true, false);
+                        break;
+                    case "EcomCurrencies":
+                        EnsureDestinationColumn(columnMappingDictionary, destColumns, "CurrencyCode", typeof(string), SqlDbType.NVarChar, null, 3, false, true, false);
+                        EnsureDestinationColumn(columnMappingDictionary, destColumns, "CurrencyLanguageId", typeof(string), SqlDbType.NVarChar, null, 50, false, true, false);
+                        break;
+                    case "EcomCountries":
+                        EnsureDestinationColumn(columnMappingDictionary, destColumns, "CountryCode2", typeof(string), SqlDbType.NVarChar, null, 2, false, true, false);
+                        EnsureDestinationColumn(columnMappingDictionary, destColumns, "CountryCultureInfo", typeof(string), SqlDbType.NVarChar, null, 15, false, true, false);
+                        EnsureDestinationColumn(columnMappingDictionary, destColumns, "CountryRegionCode", typeof(string), SqlDbType.NVarChar, null, 3, false, true, false);
+                        EnsureDestinationColumn(columnMappingDictionary, destColumns, destinationTableColumns, "CountryVAT");
+                        EnsureDestinationColumn(columnMappingDictionary, destColumns, destinationTableColumns, "CountryCode3");
+                        EnsureDestinationColumn(columnMappingDictionary, destColumns, destinationTableColumns, "CountryCurrencyCode");
+                        break;
+                    case "EcomStockLocation":
+                        EnsureDestinationColumn(columnMappingDictionary, destColumns, "StockLocationName", typeof(string), SqlDbType.NVarChar, null, 255, false, true, false);
                         break;
                 }
                 List<Mapping> tableMappings = null;
@@ -1126,6 +1151,9 @@ internal class EcomDestinationWriter : BaseSqlWriter
             case "EcomStockUnit":
                 WriteStockUnits(row, columnMappings, dataRow, mapping);
                 break;
+            case "EcomCountries":
+                WriteCountries(row, columnMappings, dataRow, mapping);
+                break;
         }
 
         foreach (ColumnMapping columnMapping in mappingColumns)
@@ -1863,7 +1891,7 @@ internal class EcomDestinationWriter : BaseSqlWriter
     private void WriteStockUnits(Dictionary<string, object> row, Dictionary<string, ColumnMapping> columnMappings, DataRow dataRow, Mapping mapping)
     {
         if (!columnMappings.TryGetValue("StockUnitId", out _))
-        {            
+        {
             if (columnMappings.TryGetValue("StockUnitProductID", out var stockUnitProductIDColumn) && columnMappings.TryGetValue("StockUnitVariantID", out var stockUnitVariantIDColumn))
             {
                 mapping.AddMapping(mapping.SourceTable.Columns.FirstOrDefault(), mapping.DestinationTable.Columns.Where(obj => obj.Name.Equals("StockUnitId", StringComparison.OrdinalIgnoreCase)).FirstOrDefault());
@@ -1879,6 +1907,40 @@ internal class EcomDestinationWriter : BaseSqlWriter
                 if (!string.IsNullOrEmpty(productBaseUnitOfMeasure))
                 {
                     dataRow["StockUnitId"] = productBaseUnitOfMeasure;
+                }
+            }
+        }
+    }
+
+    private void WriteCountries(Dictionary<string, object> row, Dictionary<string, ColumnMapping> columnMappings, DataRow dataRow, Mapping mapping)
+    {
+        if (columnMappings.TryGetValue("CountryCode2", out var countryCode2Column))
+        {
+            if (!columnMappings.TryGetValue("CountryCultureInfo", out _))
+            {
+                dataRow["CountryCultureInfo"] = "";
+            }
+
+            var countryCode2 = row[countryCode2Column.SourceColumn?.Name].ToString();
+            GlobalISO dwISO = GlobalISO.GetGlobalISOByISOCode2(countryCode2);
+            if (dwISO != null)
+            {
+                if (!columnMappings.TryGetValue("CountryVAT", out _))
+                {
+                    mapping.AddMapping(mapping.SourceTable.Columns.FirstOrDefault(), mapping.DestinationTable.Columns.Where(obj => obj.Name.Equals("CountryVAT", StringComparison.OrdinalIgnoreCase)).FirstOrDefault());
+                    dataRow["CountryVAT"] = Converter.ToDouble(dwISO.Vat);
+                }
+
+                if (!columnMappings.TryGetValue("CountryCode3", out _))
+                {
+                    mapping.AddMapping(mapping.SourceTable.Columns.FirstOrDefault(), mapping.DestinationTable.Columns.Where(obj => obj.Name.Equals("CountryCode3", StringComparison.OrdinalIgnoreCase)).FirstOrDefault());
+                    dataRow["CountryCode3"] = dwISO.Code3;
+                }
+
+                if (!columnMappings.TryGetValue("CountryCurrencyCode", out _))
+                {
+                    mapping.AddMapping(mapping.SourceTable.Columns.FirstOrDefault(), mapping.DestinationTable.Columns.Where(obj => obj.Name.Equals("CountryCurrencyCode", StringComparison.OrdinalIgnoreCase)).FirstOrDefault());
+                    dataRow["CountryCurrencyCode"] = dwISO.CurrencySymbol;
                 }
             }
         }

--- a/src/EcomDestinationWriter.cs
+++ b/src/EcomDestinationWriter.cs
@@ -3798,7 +3798,7 @@ internal class EcomDestinationWriter : BaseSqlWriter
         foreach (DataTable table in DataToWrite.Tables)
         {
             string tableName = GetTableNameWithoutPrefix(table.TableName) + "TempTableForBulkImport" + GetPrefixFromTableName(table.TableName);
-            sqlCommand.CommandText = "if exists (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'" + tableName + "') AND type in (N'U')) drop table " + tableName;
+            sqlCommand.CommandText = $"if exists (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{tableName}') AND type in (N'U')) drop table [{tableName}]";
             sqlCommand.ExecuteNonQuery();
         }
 

--- a/src/EcomProvider.cs
+++ b/src/EcomProvider.cs
@@ -208,9 +208,12 @@ public class EcomProvider : BaseSqlProvider, IParameterOptions
     {
         Schema result = GetDynamicwebSourceSchema();
         List<string> tablestToKeep = new()
-        { "EcomProducts", "EcomManufacturers", "EcomGroups", "EcomVariantGroups", "EcomVariantsOptions",
-                "EcomProductsRelated", "EcomProductItems", "EcomStockUnit", "EcomDetails","EcomProductCategoryFieldValue", "EcomLanguages", "EcomPrices",
-                "EcomAssortmentGroupRelations", "EcomAssortmentPermissions", "EcomAssortmentProductRelations", "EcomAssortments", "EcomAssortmentShopRelations", "EcomVariantOptionsProductRelation"};
+        { 
+            "EcomProducts", "EcomManufacturers", "EcomGroups", "EcomVariantGroups", "EcomVariantsOptions",
+            "EcomProductsRelated", "EcomProductItems", "EcomStockUnit", "EcomDetails","EcomProductCategoryFieldValue", "EcomLanguages", "EcomPrices",
+            "EcomAssortmentGroupRelations", "EcomAssortmentPermissions", "EcomAssortmentProductRelations", "EcomAssortments", "EcomAssortmentShopRelations", 
+            "EcomVariantOptionsProductRelation", "EcomCurrencies", "EcomCountries", "EcomStockLocation"
+        };
         List<Table> tablesToRemove = new();
         foreach (Table table in result.GetTables())
         {
@@ -729,6 +732,18 @@ public class EcomProvider : BaseSqlProvider, IParameterOptions
         if (mappings != null)
             tables.AddRange(mappings);
 
+        mappings = GetMappingsByName(job.Mappings, "EcomCountries", isSource);
+        if (mappings != null)
+            tables.AddRange(mappings);
+
+        mappings = GetMappingsByName(job.Mappings, "EcomCurrencies", isSource);
+        if (mappings != null)
+            tables.AddRange(mappings);
+
+        mappings = GetMappingsByName(job.Mappings, "EcomStockLocation", isSource);
+        if (mappings != null)
+            tables.AddRange(mappings);
+
         mappings = GetMappingsByName(job.Mappings, "EcomGroups", isSource);
         if (mappings != null)
             tables.AddRange(mappings);
@@ -828,26 +843,67 @@ public class EcomProvider : BaseSqlProvider, IParameterOptions
 
         try
         {
-            if (IsFirstJobRun)
-            {
-                Writer = new EcomDestinationWriter(job, Connection, DeactivateMissingProducts, null, RemoveMissingAfterImport, Logger,
-                UpdateOnlyExistingProducts, DefaultLanguage, DiscardDuplicates, PartialUpdate, RemoveMissingAfterImportDestinationTablesOnly, UseStrictPrimaryKeyMatching,
-                CreateMissingGoups, SkipFailingRows, UseProductIdFoundByNumber, IgnoreEmptyCategoryFieldValues);
-                if (!string.IsNullOrEmpty(Shop))
-                    Writer.DefaultShop = Shop;
-            }
-            else
-            {
-                if (Writer == null)
-                {
-                    throw new Exception($"Can not find Ecom");
-                }
-            }
-
             foreach (Mapping mapping in job.Mappings)
             {
-                if (mapping.Active && mapping.GetColumnMappings().Count > 0)
+                var columnMappings = mapping.GetColumnMappings();
+
+                if (mapping.Active && columnMappings.Count > 0)
                 {
+                    if (!string.IsNullOrEmpty(defaultLanguage))
+                    {
+                        string destinationColumnNameForLanguageId = MappingExtensions.GetLanguageIdColumnName(mapping.DestinationTable.Name);
+                        if (!string.IsNullOrEmpty(destinationColumnNameForLanguageId) && !columnMappings.Any(obj => obj.Active && obj.DestinationColumn.Name.Equals(destinationColumnNameForLanguageId, StringComparison.OrdinalIgnoreCase)))
+                        {
+                            Column randomColumn = mapping.SourceTable.Columns.First();
+                            var languageColumnMapping = mapping.AddMapping(randomColumn, mapping.DestinationTable.Columns.Find(c => string.Compare(c.Name, MappingExtensions.GetLanguageIdColumnName(mapping.DestinationTable.Name), true) == 0), true);
+                            languageColumnMapping.ScriptType = ScriptType.Constant;
+                            languageColumnMapping.ScriptValue = defaultLanguage;
+                        }
+                    }
+
+                    if (!string.IsNullOrEmpty(Shop))
+                    {
+                        string destinationColumnNameForShopId = MappingExtensions.GetShopIdColumnName(mapping.DestinationTable.Name);
+                        if (!string.IsNullOrEmpty(destinationColumnNameForShopId) && !columnMappings.Any(obj => obj.Active && obj.DestinationColumn.Name.Equals(destinationColumnNameForShopId, StringComparison.OrdinalIgnoreCase)))
+                        {
+                            Column randomColumn = mapping.SourceTable.Columns.First();
+                            var shopColumnMapping = mapping.AddMapping(randomColumn, mapping.DestinationTable.Columns.Find(c => string.Compare(c.Name, MappingExtensions.GetShopIdColumnName(mapping.DestinationTable.Name), true) == 0));
+                            shopColumnMapping.ScriptType = ScriptType.Constant;
+                            shopColumnMapping.ScriptValue = Shop;
+                        }
+                    }
+
+                    var ecomProductTableMapping = job.Mappings.Where(obj => obj != null && obj.Active && obj.DestinationTable != null && obj.DestinationTable.Name.Equals("EcomProducts", StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
+                    if (ecomProductTableMapping != null)
+                    {
+                        if (ecomProductTableMapping.DestinationTable != null && !ecomProductTableMapping.GetColumnMappings().Any(obj => obj.DestinationColumn != null && obj.DestinationColumn.Name.Equals("ProductVariantId", StringComparison.OrdinalIgnoreCase)))
+                        {
+                            Column randomColumn = mapping.SourceTable.Columns.First();
+                            var shopColumnMapping = mapping.AddMapping(randomColumn, ecomProductTableMapping.DestinationTable.Columns.Find(c => string.Compare(c.Name, "ProductVariantId", true) == 0), true);
+                            shopColumnMapping.ScriptType = ScriptType.Constant;
+                            shopColumnMapping.ScriptValue = string.Empty;
+                        }
+                    }
+
+                    if (IsFirstJobRun)
+                    {
+                        Writer = new EcomDestinationWriter(job, Connection, DeactivateMissingProducts, null, RemoveMissingAfterImport, Logger,
+                        UpdateOnlyExistingProducts, DefaultLanguage, DiscardDuplicates, PartialUpdate, RemoveMissingAfterImportDestinationTablesOnly, UseStrictPrimaryKeyMatching,
+                        CreateMissingGoups, SkipFailingRows, UseProductIdFoundByNumber, IgnoreEmptyCategoryFieldValues);
+                        if (!string.IsNullOrEmpty(Shop))
+                        {
+                            Writer.DefaultShop = Shop;
+                        }
+                    }
+                    else
+                    {
+                        if (Writer == null)
+                        {
+                            throw new Exception($"Can not find Ecom");
+                        }
+                    }
+
+
                     Logger.Log("Starting import to temporary table for " + mapping.DestinationTable.Name + ".");
                     using (var reader = job.Source.GetReader(mapping))
                     {

--- a/src/EcomProvider.cs
+++ b/src/EcomProvider.cs
@@ -991,10 +991,7 @@ public class EcomProvider : BaseSqlProvider, IParameterOptions
         }
         finally
         {
-            if (exception != null)
-            {
-                Writer?.Close();
-            }
+            Writer?.Close();
         }
         if (IsFirstJobRun)
         {


### PR DESCRIPTION
…n to the schema plus added them in the OrderTablesInJob function. Added extra logic to the RunJob function, so it now added column-mappings for LanguageID and ShopID when missing and custom-logic for EcomProducts when ProductVariantId is not mapped. In EcomDestinationWriter changed some of "EnsureDestinationColumn" logic in the CreateTempTables-function, as some of the columns are PrimaryKeys to avoid "Violation of PRIMARY KEY constraint" plus added the 3 new tables. added WriteCountries to get extra values from GlobalISO. Bump version to 10.0.15

[AB#16918](https://dev.azure.com/dynamicwebsoftware/5a2edd81-7d89-4716-a4f3-1187ba91af92/_workitems/edit/16918)