### PR TITLE
Relations dictionary to order tables

### DIFF
--- a/src/Dynamicweb.DataIntegration.Providers.EcomProvider.csproj
+++ b/src/Dynamicweb.DataIntegration.Providers.EcomProvider.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<Version>10.0.24</Version>
+		<Version>10.0.25</Version>
 		<AssemblyVersion>1.0.0.0</AssemblyVersion>
 		<Title>Ecom Provider</Title>
 		<Description>Ecom Provider</Description>
@@ -14,7 +14,7 @@
 		<Copyright>Copyright © 2023 Dynamicweb Software A/S</Copyright>
 	</PropertyGroup>
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<IncludeSymbols>true</IncludeSymbols>
 		<EmbedUntrackedSources>true</EmbedUntrackedSources>
@@ -23,8 +23,8 @@
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Dynamicweb.DataIntegration" Version="10.0.19" />
-		<PackageReference Include="Dynamicweb.Ecommerce" Version="10.0.9" />
+		<PackageReference Include="Dynamicweb.DataIntegration" Version="10.4.0" />
+		<PackageReference Include="Dynamicweb.Ecommerce" Version="10.4.0" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
We might be able to make a default implementation like this that takes a dictionary and orders things properly, but for now I have put it as a provider specific implementation to get some thoughts.

In general I would like some feedback on this sort of way of doing it - it requires changes in the BaseProvider (hence this would bump the dependencies to 10.4.0 and should not be merged till we actually make a release with those new additions)

I do realize that if we have a dependency that says table C has a foreign key to B and B has a foreign key to A, then A should always be first, but in this implementation that is not considered as there is no relations that goes like that, only 1 step down.