### PR TITLE
added duplicateRowsHandler when the destinationtable is EcomVariantGr…

### DIFF
--- a/src/Dynamicweb.DataIntegration.Providers.EcomProvider.csproj
+++ b/src/Dynamicweb.DataIntegration.Providers.EcomProvider.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<Version>10.8.1</Version>
+		<Version>10.8.2</Version>
 		<AssemblyVersion>1.0.0.0</AssemblyVersion>
 		<Title>Ecom Provider</Title>
 		<Description>Ecom Provider</Description>

--- a/src/EcomDestinationWriter.cs
+++ b/src/EcomDestinationWriter.cs
@@ -1107,6 +1107,7 @@ internal class EcomDestinationWriter : BaseSqlWriter
                 break;
             case "EcomVariantGroups":
                 WriteVariantGroups(row, columnMappings, dataRow);
+                duplicateRowsHandler ??= new DuplicateRowsHandler(logger, job.Mappings);
                 break;
             case "EcomVariantsOptions":
                 WriteVariantOptions(row, columnMappings, dataRow);


### PR DESCRIPTION
[AB#19259](https://dev.azure.com/dynamicwebsoftware/Dynamicweb/_workitems/edit/19259/)

always use the duplicateRowsHandler when writting variantgroups into DW10 EcomVariantGroups