### PR TITLE
in AddMappingsToJobThatNeedsToBeThereForMoveToMainTables when working…

### DIFF
--- a/src/Dynamicweb.DataIntegration.Providers.EcomProvider.csproj
+++ b/src/Dynamicweb.DataIntegration.Providers.EcomProvider.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<Version>10.9.2</Version>
+		<Version>10.9.3</Version>
 		<AssemblyVersion>1.0.0.0</AssemblyVersion>
 		<Title>Ecom Provider</Title>
 		<Description>Ecom Provider</Description>

--- a/src/EcomDestinationWriter.cs
+++ b/src/EcomDestinationWriter.cs
@@ -3421,14 +3421,17 @@ internal class EcomDestinationWriter : BaseSqlWriter
         List<Mapping>? productsMappings = null;
         if (HasData("EcomProducts") && Mappings.TryGetValue("EcomProducts", out productsMappings))
         {
-            foreach (var ecomProductsMapping in productsMappings)
+            if (!updateOnlyExistingProducts)
             {
-                EnsureMapping(ecomProductsMapping, DestinationColumnMappings["EcomProducts"], tableColumnsDictionary["EcomProducts"],
-                    new string[] { "ProductID", "ProductVariantID", "ProductLanguageID" });
-                EnsureMapping(ecomProductsMapping, DestinationColumnMappings["EcomProducts"], tableColumnsDictionary["EcomProducts"],
-                    new string[] { "ProductVariantCounter" });
+                foreach (var ecomProductsMapping in productsMappings)
+                {
+                    EnsureMapping(ecomProductsMapping, DestinationColumnMappings["EcomProducts"], tableColumnsDictionary["EcomProducts"],
+                        new string[] { "ProductID", "ProductVariantID", "ProductLanguageID" });
+                    EnsureMapping(ecomProductsMapping, DestinationColumnMappings["EcomProducts"], tableColumnsDictionary["EcomProducts"],
+                        new string[] { "ProductVariantCounter" });
 
-                HandleIsKeyColumns(ecomProductsMapping, new string[] { "ProductVariantID", "ProductLanguageID" });
+                    HandleIsKeyColumns(ecomProductsMapping, new string[] { "ProductVariantID", "ProductLanguageID" });
+                }
             }
         }
 


### PR DESCRIPTION
… with EcomProducts a check for updateOnlyExistingProducts is added, so the columns are only being added when it is not doing just an update. bump version to 10.9.3